### PR TITLE
LTB-12 | fix: Fix TypeError: the JSON object must be str, bytes or bytearray, not dict

### DIFF
--- a/letraz_server/contrib/middlewares/clerk_middlewares.py
+++ b/letraz_server/contrib/middlewares/clerk_middlewares.py
@@ -44,7 +44,25 @@ class ClerkAuthenticationMiddleware(BaseAuthentication):
 
     def decode_jwt(self, token):
         jwks_data = self.clerk.get_jwks()
-        public_key = RSAAlgorithm.from_jwk(json.dumps(jwks_data['keys'][0]))
+        try:
+            if not jwks_data.get('keys'):
+                logger.error('Invalid JWKS: missing or empty keys array')
+                raise AuthenticationFailed('Invalid JWKS format')
+            
+            jwk_data = jwks_data['keys'][0]
+            try:
+                jwk_str = json.dumps(jwk_data)
+            except (TypeError, ValueError) as e:
+                logger.error(f'Failed to serialize JWK: {e}')
+                raise AuthenticationFailed('Invalid key format in JWKS')
+                
+            public_key = RSAAlgorithm.from_jwk(jwk_str)
+        except IndexError:
+            logger.error('Invalid JWKS: keys array is empty')
+            raise AuthenticationFailed('Invalid JWKS format')
+        except Exception as e:
+            logger.error(f'Failed to parse JWKS: {e}')
+            raise AuthenticationFailed('Failed to process JWKS')
         try:
             payload = jwt.decode(
                 token,

--- a/letraz_server/contrib/middlewares/clerk_middlewares.py
+++ b/letraz_server/contrib/middlewares/clerk_middlewares.py
@@ -44,7 +44,7 @@ class ClerkAuthenticationMiddleware(BaseAuthentication):
 
     def decode_jwt(self, token):
         jwks_data = self.clerk.get_jwks()
-        public_key = RSAAlgorithm.from_jwk(jwks_data['keys'][0])
+        public_key = RSAAlgorithm.from_jwk(json.dumps(jwks_data['keys'][0]))
         try:
             payload = jwt.decode(
                 token,


### PR DESCRIPTION
### Issue:
[LTB-12 | TypeError: the JSON object must be str, bytes or bytearray, not dict](https://linear.app/letraz/issue/LTB-12/typeerror-the-json-object-must-be-str-bytes-or-bytearray-not-dict)

### Description:
This pull request addresses the TypeError occurring in the `decode_jwt` function due to incorrect JSON object type.

### Changes Made:
- Updated the `decode_jwt` function in `clerk_middlewares.py` to handle JSON object type correctly.
- Added validation checks to ensure the JSON object passed is of type str, bytes, or bytearray.
- Improved error handling and logging for better debugging.
- Tested the changes with relevant unit tests to ensure the issue is resolved.

### Closing Note:
This PR is crucial as it fixes a critical TypeError that was causing the application to fail when decoding JSON objects. By addressing this issue, we ensure the stability and reliability of the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced error handling and validation in the authentication middleware for improved JWT decoding.
	- Updated logic for key extraction to ensure better handling of invalid key formats and added logging for failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->