### PR TITLE
LTB-26 | fix: Unauthenticated APIs failing with 'Invalid Bearer token provided if any cookie is present in request

### DIFF
--- a/letraz_server/contrib/middlewares/clerk_middlewares.py
+++ b/letraz_server/contrib/middlewares/clerk_middlewares.py
@@ -28,7 +28,7 @@ class ClerkAuthenticationMiddleware(BaseAuthentication):
     def authenticate(self, request):
         authentication_cookies = request.COOKIES
         authentication_header = request.headers.get('Authorization')
-        if not (authentication_cookies or authentication_header):
+        if not (authentication_cookies.get('__session') or authentication_header):
             return None, None
         try:
             if authentication_cookies.get('__session'):


### PR DESCRIPTION
### Issue:
[LTB-26 | fix: unauthenticated APIs failing with 'Invalid Bearer token provided' if any cookie is present in request](https://linear.app/letraz/issue/LTB-26/fix-unauthenticated-apis-failing-with-invalid-bearer-token-provided-if)

### Description:
This pull request addresses the issue where unauthenticated API endpoints are erroneously failing with the "Invalid Bearer token provided" error when any cookie is present in the request, even if it's not a valid authentication cookie.

### Changes Made:
- Identified affected endpoints triggering the error incorrectly.
- Reviewed and adjusted authentication middleware/decorators to skip bearer token validation for unauthenticated endpoints.
- Conducted thorough testing on affected API endpoints with different cookie scenarios to ensure correct functionality.

### Closing Note:
By fixing the authentication logic to handle unauthenticated endpoints properly, this PR eliminates the "Invalid Bearer token provided" error for unauthenticated endpoints, ensuring consistent functionality regardless of cookie presence.