### PR TITLE
LTB-73 | bug: Authentication failing due to JWKS mismatch with Clerk

### DIFF
--- a/letraz_server/contrib/middlewares/clerk_middlewares.py
+++ b/letraz_server/contrib/middlewares/clerk_middlewares.py
@@ -63,37 +63,65 @@ class ClerkAuthenticationMiddleware(BaseAuthentication):
             logger.error(f'Failed to decode JWT header: {e}')
             raise AuthenticationFailed('Invalid token format')
         
-        # Get JWKS data
-        jwks_data = self.clerk.get_jwks()
+        # Get the issuer from the JWT payload to determine the correct JWKS endpoint
         try:
+            payload = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+            issuer = payload.get('iss')
+            if not issuer:
+                logger.error('JWT payload missing issuer')
+                raise AuthenticationFailed('Invalid token: missing issuer')
+        except jwt.DecodeError as e:
+            logger.error(f'Failed to decode JWT payload: {e}')
+            raise AuthenticationFailed('Invalid token format')
+        
+        # Get JWKS data using the issuer URL
+        try:
+            jwks_data = self.clerk.get_jwks_from_issuer(issuer)
+            logger.debug(f'JWKS data retrieved: {jwks_data}')
+        except Exception as e:
+            logger.error(f'Failed to get JWKS data: {str(e)}')
+            raise AuthenticationFailed(f'Failed to get JWKS data: {str(e)}')
+        
+        try:
+            if not jwks_data or not isinstance(jwks_data, dict):
+                logger.error('Invalid JWKS: not a valid dictionary')
+                raise AuthenticationFailed('Invalid JWKS format')
+            
             if not jwks_data.get('keys'):
                 logger.error('Invalid JWKS: missing or empty keys array')
                 raise AuthenticationFailed('Invalid JWKS format')
             
             # Find the key that matches the kid
             jwk_data = None
+            available_kids = []
             for key in jwks_data['keys']:
-                if key.get('kid') == kid:
+                key_kid = key.get('kid')
+                available_kids.append(key_kid)
+                if key_kid == kid:
                     jwk_data = key
                     break
             
             if not jwk_data:
-                logger.error(f'No matching key found for kid: {kid}')
+                logger.error(f'No matching key found for kid: {kid}. Available kids: {available_kids}')
                 raise AuthenticationFailed('Invalid token: key not found')
             
             try:
                 jwk_str = json.dumps(jwk_data)
+                logger.debug(f'JWK data for kid {kid}: {jwk_str}')
             except (TypeError, ValueError) as e:
                 logger.error(f'Failed to serialize JWK: {e}')
                 raise AuthenticationFailed('Invalid key format in JWKS')
                 
             public_key = RSAAlgorithm.from_jwk(jwk_str)
-        except IndexError:
-            logger.error('Invalid JWKS: keys array is empty')
-            raise AuthenticationFailed('Invalid JWKS format')
+            logger.debug(f'Successfully created public key for kid: {kid}')
+            
+        except AuthenticationFailed:
+            # Re-raise authentication errors
+            raise
         except Exception as e:
             logger.error(f'Failed to parse JWKS: {e}')
-            raise AuthenticationFailed('Failed to process JWKS')
+            logger.error(f'JWKS data: {jwks_data}')
+            raise AuthenticationFailed(f'Failed to process JWKS: {str(e)}')
         try:
             payload = jwt.decode(
                 token,

--- a/letraz_server/contrib/sdks/clerk.py
+++ b/letraz_server/contrib/sdks/clerk.py
@@ -51,13 +51,43 @@ class ClerkSDK:
             }
 
     def get_jwks(self):
-        jwks_data = cache.get(self.CACHE_KEY)
+        """Get JWKS from the configured frontend API URL"""
+        return self._fetch_jwks(self.FRONTEND_API_URL)
+    
+    def get_jwks_from_issuer(self, issuer_url):
+        """Get JWKS from the issuer URL (extracted from JWT token)"""
+        return self._fetch_jwks(issuer_url)
+    
+    def _fetch_jwks(self, base_url):
+        """Internal method to fetch JWKS from a given base URL"""
+        # Create cache key based on the base URL
+        cache_key = f"jwks_data_{base_url.replace('https://', '').replace('/', '_')}"
+        
+        jwks_data = cache.get(cache_key)
         if not jwks_data:
-            response = requests.get(f'{self.FRONTEND_API_URL}/.well-known/jwks.json')
-            if response.status_code == 200:
-                jwks_data = response.json()
-                logger.debug(f'JWKS Keys:  {jwks_data}')
-                cache.set(self.CACHE_KEY, jwks_data)
-            else:
-                raise AuthenticationFailed('Failed to fetch JWKS!')
+            jwks_url = f'{base_url}/.well-known/jwks.json'
+            logger.info(f'Fetching JWKS from: {jwks_url}')
+            
+            try:
+                response = requests.get(jwks_url, timeout=10)
+                logger.info(f'JWKS response status: {response.status_code}')
+                
+                if response.status_code == 200:
+                    jwks_data = response.json()
+                    logger.debug(f'JWKS Keys: {jwks_data}')
+                    # Add cache timeout to prevent indefinite caching
+                    cache.set(cache_key, jwks_data, timeout=300)  # 5 minutes
+                else:
+                    logger.error(f'Failed to fetch JWKS. Status: {response.status_code}, Response: {response.text}')
+                    raise AuthenticationFailed(f'Failed to fetch JWKS! Status: {response.status_code}')
+            except requests.exceptions.RequestException as e:
+                logger.error(f'Request error when fetching JWKS: {str(e)}')
+                raise AuthenticationFailed(f'JWKS request failed: {str(e)}')
+            except ValueError as e:
+                logger.error(f'Invalid JSON response from JWKS endpoint: {str(e)}')
+                raise AuthenticationFailed('Invalid JWKS response format')
+            except Exception as e:
+                logger.error(f'Unexpected error fetching JWKS: {str(e)}')
+                raise AuthenticationFailed(f'Unexpected JWKS error: {str(e)}')
+        
         return jwks_data


### PR DESCRIPTION
### Issue:
[LTB-73 | bug: Authentication failing due to JWKS mismatch with Clerk](https://linear.app/letraz/issue/LTB-73/bug-authentication-failing-due-to-jwks-mismatch-with-clerk)

### Description:
This PR addresses the authentication failure in the `letraz-server` due to JWKS mismatch with Clerk by updating the logic for fetching and caching JWKS data.

### Changes Made:
- Modified `decode_jwt` method in `clerk_middlewares.py` to fetch JWKS data using the issuer URL extracted from the JWT token.
- Updated `get_jwks` and added `get_jwks_from_issuer` methods in `clerk.py` to fetch JWKS data from the configured frontend API URL and issuer URL respectively.
- Improved caching mechanism to store and retrieve JWKS data based on the base URL.
- Enhanced error handling for decoding JWT payload and fetching JWKS data.

### Closing Note:
This PR is crucial as it resolves the critical P0 bug affecting all users by ensuring proper authentication using Clerk JWTs. The changes made here will enable the `letraz-server` to authenticate user requests successfully and eliminate JWKS validation errors, allowing the application to function without authentication issues.