### PR TITLE
LTB-103 | api: API endpoint for replacing an entire resume object with a new object

### DIFF
--- a/RESUME/api_views.py
+++ b/RESUME/api_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import uuid
 from http import HTTPStatus
 from django.db.models import QuerySet
 from django.db import transaction
@@ -134,125 +135,279 @@ class ResumeViewSets(viewsets.GenericViewSet):
                     # Remove all existing sections and cascades
                     resume.resumesection_set.all().delete()
 
-                    # Recreate incoming sections preserving order
+                    # Prepare bulk creation containers
+                    new_sections: list[ResumeSection] = []
+                    # Keep mapping of enumerated index -> created section id for each type as we preserve original indices
+                    experience_payloads: list[dict] = []
+                    education_payloads: list[dict] = []
+                    project_payloads: list[dict] = []
+                    project_skills_used_map: dict[str, list[dict]] = {}
+                    certification_payloads: list[dict] = []
+
+                    # Skills handling
+                    explicit_skill_sections: dict[str, list[dict]] = {}  # section_id -> list of skill items
+                    first_skill_section_id: str | None = None
+                    project_skill_items: list[dict] = []  # list of {'name','category'} from projects
+
+                    # 1) Build all sections (pre-generate UUIDs) and organize payloads
                     for index, section in enumerate(sections_payload):
                         section_type = section.get('type')
                         section_data = section.get('data') or {}
 
                         if section_type == 'Skill':
-                            if section_data.get('skills'):
-                                new_res_sec: ResumeSection = resume.resumesection_set.create(
-                                    index=index, type=ResumeSection.ResumeSectionType.Skill.value
-                                )
-                                for skill_item in section_data.get('skills'):
-                                    skill_info = (skill_item or {}).get('skill') or {}
-                                    skill_name = skill_info.get('name')
-                                    skill_category = skill_info.get('category')
-                                    if not skill_name:
-                                        continue
-                                    target_skill, _ = Skill.objects.get_or_create(
-                                        name=skill_name, category=skill_category
-                                    )
-                                    target_proficiency, _ = new_res_sec.proficiency_set.get_or_create(
-                                        skill=target_skill
-                                    )
-                                    skill_level = (skill_item or {}).get('level')
-                                    if skill_level and str(skill_level) in Proficiency.Level.values:
-                                        target_proficiency.level = skill_level
-                                    target_proficiency.save()
-
-                        elif section_type == 'Experience':
-                            new_res_sec: ResumeSection = resume.resumesection_set.create(
-                                index=index, type=ResumeSection.ResumeSectionType.Experience.value
-                            )
-                            payload = dict(section_data)
-                            payload['user'] = self.authenticated_user.id
-                            payload['resume_section'] = new_res_sec.id
-                            experience_ser = ExperienceUpsertSerializer(data=payload)
-                            if experience_ser.is_valid():
-                                experience_ser.save()
-                            else:
-                                # cleanup the created section before failing
-                                new_res_sec.delete()
-                                return ErrorResponse(
-                                    code=ErrorCode.INVALID_REQUEST,
-                                    message='Invalid Experience data provided.',
-                                    details=experience_ser.errors,
-                                    extra={'data': section_data}
-                                ).response
-
-                        elif section_type == 'Education':
-                            new_res_sec: ResumeSection = resume.resumesection_set.create(
-                                index=index, type=ResumeSection.ResumeSectionType.Education.value
-                            )
-                            payload = dict(section_data)
-                            payload['user'] = self.authenticated_user.id
-                            payload['resume_section'] = new_res_sec.id
-                            education_ser = EducationUpsertSerializer(data=payload)
-                            if education_ser.is_valid():
-                                education_ser.save()
-                            else:
-                                new_res_sec.delete()
-                                return ErrorResponse(
-                                    code=ErrorCode.INVALID_REQUEST,
-                                    message='Invalid Education data provided.',
-                                    details=education_ser.errors,
-                                    extra={'data': section_data}
-                                ).response
-
-                        elif section_type == 'Project':
-                            new_res_sec: ResumeSection = resume.resumesection_set.create(
-                                index=index, type=ResumeSection.ResumeSectionType.Project.value
-                            )
-                            payload = dict(section_data)
-                            skills_used = payload.get('skills_used')
-                            if 'skills_used' in payload:
-                                del payload['skills_used']
-                            payload['user'] = self.authenticated_user.id
-                            payload['resume_section'] = new_res_sec.id
-                            project_ser = ProjectUpsertSerializer(data=payload)
-                            if project_ser.is_valid():
-                                new_project: Project = project_ser.save()
-                                # Align with other endpoints: add skills via model helper
-                                if isinstance(skills_used, list):
-                                    for sk in skills_used:
-                                        if not sk:
-                                            continue
-                                        sk_name = sk.get('name')
-                                        sk_cat = sk.get('category')
-                                        if not sk_name:
-                                            continue
-                                        new_project.add_skill(skill_name=sk_name, skill_category=sk_cat)
-                            else:
-                                new_res_sec.delete()
-                                return ErrorResponse(
-                                    code=ErrorCode.INVALID_REQUEST,
-                                    message='Invalid Project data provided.',
-                                    details=project_ser.errors,
-                                    extra={'data': section_data}
-                                ).response
-
-                        elif section_type == 'Certification':
-                            new_res_sec: ResumeSection = resume.resumesection_set.create(
-                                index=index, type=ResumeSection.ResumeSectionType.Certification.value
-                            )
-                            payload = dict(section_data)
-                            payload['user'] = self.authenticated_user.id
-                            payload['resume_section'] = new_res_sec.id
-                            cert_ser = CertificationUpsertSerializer(data=payload)
-                            if cert_ser.is_valid():
-                                cert_ser.save()
-                            else:
-                                new_res_sec.delete()
-                                return ErrorResponse(
-                                    code=ErrorCode.INVALID_REQUEST,
-                                    message='Invalid Certification data provided.',
-                                    details=cert_ser.errors,
-                                    extra={'data': section_data}
-                                ).response
-                        else:
-                            # Unknown section types are ignored to keep robustness
+                            skills_list = section_data.get('skills') or []
+                            if not skills_list:
+                                # Skip creating empty Skill sections (matches previous behavior)
+                                continue
+                            sec_id = uuid.uuid4()
+                            sec = ResumeSection(id=sec_id, resume=resume, index=index,
+                                                type=ResumeSection.ResumeSectionType.Skill.value)
+                            new_sections.append(sec)
+                            explicit_skill_sections[str(sec_id)] = skills_list
+                            if not first_skill_section_id:
+                                first_skill_section_id = str(sec_id)
                             continue
+
+                        if section_type == 'Experience':
+                            sec_id = uuid.uuid4()
+                            new_sections.append(ResumeSection(
+                                id=sec_id, resume=resume, index=index,
+                                type=ResumeSection.ResumeSectionType.Experience.value
+                            ))
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = sec_id
+                            experience_payloads.append(payload)
+                            continue
+
+                        if section_type == 'Education':
+                            sec_id = uuid.uuid4()
+                            new_sections.append(ResumeSection(
+                                id=sec_id, resume=resume, index=index,
+                                type=ResumeSection.ResumeSectionType.Education.value
+                            ))
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = sec_id
+                            education_payloads.append(payload)
+                            continue
+
+                        if section_type == 'Project':
+                            sec_id = uuid.uuid4()
+                            new_sections.append(ResumeSection(
+                                id=sec_id, resume=resume, index=index,
+                                type=ResumeSection.ResumeSectionType.Project.value
+                            ))
+                            payload = dict(section_data)
+                            skills_used = payload.pop('skills_used', None)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = sec_id
+                            project_payloads.append(payload)
+                            if isinstance(skills_used, list):
+                                project_skills_used_map[str(sec_id)] = skills_used
+                                # Collect skills for global resolution
+                                for sk in skills_used:
+                                    if sk:
+                                        project_skill_items.append({'name': sk.get('name'), 'category': sk.get('category')})
+                            continue
+
+                        if section_type == 'Certification':
+                            sec_id = uuid.uuid4()
+                            new_sections.append(ResumeSection(
+                                id=sec_id, resume=resume, index=index,
+                                type=ResumeSection.ResumeSectionType.Certification.value
+                            ))
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = sec_id
+                            certification_payloads.append(payload)
+                            continue
+
+                        # Unknown types: ignore
+
+                    # If there are project skills but no explicit Skill section, create one at the end
+                    if project_skill_items and not first_skill_section_id:
+                        sec_id = uuid.uuid4()
+                        next_index = (max([s.index for s in new_sections], default=-1) + 1)
+                        new_sections.append(ResumeSection(
+                            id=sec_id, resume=resume, index=next_index,
+                            type=ResumeSection.ResumeSectionType.Skill.value
+                        ))
+                        first_skill_section_id = str(sec_id)
+
+                    # 2) Bulk create all sections
+                    if new_sections:
+                        ResumeSection.objects.bulk_create(new_sections, batch_size=500)
+
+                    # 3) Validate and bulk create children
+                    # Experience
+                    if experience_payloads:
+                        exp_ser = ExperienceUpsertSerializer(data=experience_payloads, many=True)
+                        if not exp_ser.is_valid():
+                            return ErrorResponse(
+                                code=ErrorCode.INVALID_REQUEST,
+                                message='Invalid Experience data provided.',
+                                details=exp_ser.errors,
+                                extra={'data': experience_payloads}
+                            ).response
+                        exp_instances = [
+                            Experience(**item) for item in exp_ser.validated_data
+                        ]
+                        if exp_instances:
+                            Experience.objects.bulk_create(exp_instances, batch_size=500)
+
+                    # Education
+                    if education_payloads:
+                        edu_ser = EducationUpsertSerializer(data=education_payloads, many=True)
+                        if not edu_ser.is_valid():
+                            return ErrorResponse(
+                                code=ErrorCode.INVALID_REQUEST,
+                                message='Invalid Education data provided.',
+                                details=edu_ser.errors,
+                                extra={'data': education_payloads}
+                            ).response
+                        edu_instances = [
+                            Education(**item) for item in edu_ser.validated_data
+                        ]
+                        if edu_instances:
+                            Education.objects.bulk_create(edu_instances, batch_size=500)
+
+                    # Project
+                    created_projects_by_section: dict[str, Project] = {}
+                    if project_payloads:
+                        prj_ser = ProjectUpsertSerializer(data=project_payloads, many=True)
+                        if not prj_ser.is_valid():
+                            return ErrorResponse(
+                                code=ErrorCode.INVALID_REQUEST,
+                                message='Invalid Project data provided.',
+                                details=prj_ser.errors,
+                                extra={'data': project_payloads}
+                            ).response
+                        prj_instances: list[Project] = []
+                        for item in prj_ser.validated_data:
+                            # Pre-assign UUID so we can reference for M2M
+                            prj_id = uuid.uuid4()
+                            inst = Project(id=prj_id, **item)
+                            prj_instances.append(inst)
+                        if prj_instances:
+                            Project.objects.bulk_create(prj_instances, batch_size=500)
+                            for inst in prj_instances:
+                                created_projects_by_section[str(inst.resume_section_id)] = inst
+
+                    # Certification
+                    if certification_payloads:
+                        cert_ser = CertificationUpsertSerializer(data=certification_payloads, many=True)
+                        if not cert_ser.is_valid():
+                            return ErrorResponse(
+                                code=ErrorCode.INVALID_REQUEST,
+                                message='Invalid Certification data provided.',
+                                details=cert_ser.errors,
+                                extra={'data': certification_payloads}
+                            ).response
+                        cert_instances = [
+                            Certification(**item) for item in cert_ser.validated_data
+                        ]
+                        if cert_instances:
+                            Certification.objects.bulk_create(cert_instances, batch_size=500)
+
+                    # 4) Resolve Skills once
+                    # Gather unique skills from explicit skill sections and project skills
+                    unique_skill_keys: set[tuple[str | None, str | None]] = set()
+                    # explicit skills
+                    for sec_id, skills_list in explicit_skill_sections.items():
+                        for skill_item in skills_list:
+                            if not skill_item:
+                                continue
+                            sk_info = (skill_item or {}).get('skill') or {}
+                            sk_name = sk_info.get('name')
+                            if not sk_name:
+                                continue
+                            unique_skill_keys.add((sk_name, sk_info.get('category')))
+                    # project skills
+                    for sk in project_skill_items:
+                        if not sk or not sk.get('name'):
+                            continue
+                        unique_skill_keys.add((sk.get('name'), sk.get('category')))
+
+                    skill_lookup: dict[tuple[str | None, str | None], Skill] = {}
+                    if unique_skill_keys:
+                        names = list({n for (n, _c) in unique_skill_keys if n})
+                        cats = list({c for (_n, c) in unique_skill_keys})
+                        existing_skills = Skill.objects.filter(name__in=names, category__in=cats)
+                        for s in existing_skills:
+                            skill_lookup[(s.name, s.category)] = s
+                        missing = [
+                            Skill(name=name, category=cat)
+                            for (name, cat) in unique_skill_keys
+                            if (name, cat) not in skill_lookup
+                        ]
+                        if missing:
+                            Skill.objects.bulk_create(missing, batch_size=500)
+                            for s in missing:
+                                skill_lookup[(s.name, s.category)] = s
+
+                    # 5) Bulk create Proficiencies for explicit Skill sections
+                    prof_instances: list[Proficiency] = []
+                    for sec_id, skills_list in explicit_skill_sections.items():
+                        for skill_item in skills_list:
+                            if not skill_item:
+                                continue
+                            sk_info = (skill_item or {}).get('skill') or {}
+                            sk_name = sk_info.get('name')
+                            if not sk_name:
+                                continue
+                            sk_cat = sk_info.get('category')
+                            level = (skill_item or {}).get('level')
+                            level_val = level if level and str(level) in Proficiency.Level.values else None
+                            skill_obj = skill_lookup.get((sk_name, sk_cat))
+                            if not skill_obj:
+                                continue
+                            prof_instances.append(
+                                Proficiency(resume_section_id=sec_id, skill_id=skill_obj.id, level=level_val)
+                            )
+
+                    # Add project skills to the first skill section (or the implicit one we created)
+                    if first_skill_section_id and project_skill_items:
+                        # Avoid duplicates that may already be added via explicit sections
+                        existing_pairs = set()
+                        for p in prof_instances:
+                            if str(p.resume_section_id) == str(first_skill_section_id):
+                                # For safety capture against duplicates by skill id
+                                existing_pairs.add(p.skill_id)
+                        for sk in project_skill_items:
+                            name = sk.get('name')
+                            if not name:
+                                continue
+                            cat = sk.get('category')
+                            skill_obj = skill_lookup.get((name, cat))
+                            if not skill_obj:
+                                continue
+                            if skill_obj.id in existing_pairs:
+                                continue
+                            prof_instances.append(
+                                Proficiency(resume_section_id=first_skill_section_id, skill_id=skill_obj.id, level=None)
+                            )
+
+                    if prof_instances:
+                        Proficiency.objects.bulk_create(prof_instances, batch_size=500, ignore_conflicts=True)
+
+                    # 6) Bulk create Project.skills_used M2M through rows
+                    if created_projects_by_section and project_skills_used_map:
+                        through_model = Project.skills_used.through
+                        m2m_instances = []
+                        for sec_id, skills_used in project_skills_used_map.items():
+                            prj = created_projects_by_section.get(str(sec_id))
+                            if not prj:
+                                continue
+                            for sk in skills_used:
+                                if not sk or not sk.get('name'):
+                                    continue
+                                skill_obj = skill_lookup.get((sk.get('name'), sk.get('category')))
+                                if not skill_obj:
+                                    continue
+                                m2m_instances.append(through_model(project_id=prj.id, skill_id=skill_obj.id))
+                        if m2m_instances:
+                            through_model.objects.bulk_create(m2m_instances, batch_size=500, ignore_conflicts=True)
 
                     # Clean skip flag before leaving transaction
                     if hasattr(resume, '_skip_thumbnail_generation'):

--- a/RESUME/api_views.py
+++ b/RESUME/api_views.py
@@ -9,7 +9,7 @@ from rest_framework import status, viewsets, serializers
 from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 from google.protobuf.json_format import MessageToDict
-from CORE.models import Process
+from CORE.models import Process, Country, Skill
 from CORE.serializers import ErrorSerializer
 from JOB.models import Job
 from JOB.serializers import JobFullSerializer, JobSerializer
@@ -18,7 +18,8 @@ from RESUME.models import Resume, Education, Experience, ResumeSection, Proficie
 from RESUME.serializers import ResumeShortSerializer, ResumeFullSerializer, EducationFullSerializer, \
     ExperienceFullSerializer, EducationUpsertSerializer, ExperienceUpsertSerializer, ProficiencySerializer, \
     ProjectSerializer, ResumeSkillUpsertSerializer, ProjectUpsertSerializer, CertificationSerializer, \
-    CertificationUpsertSerializer, SectionRearrangeSerializer, BaseResumeFullSerializer, BaseResumeUtilSerializer
+    CertificationUpsertSerializer, SectionRearrangeSerializer, BaseResumeFullSerializer, BaseResumeUtilSerializer, \
+    ResumeReplaceSerializer
 from RESUME.utils import (
     call_tailor_resume_util_service,
     index_resume_by_id_async,
@@ -89,6 +90,198 @@ class ResumeViewSets(viewsets.GenericViewSet):
             return ErrorResponse(
                 code=ErrorCode.NOT_FOUND, message='Resume not found!', details={'resume': resume_id}
             ).response
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='id', description='Resume ID', required=True, location=OpenApiParameter.PATH,
+                             type=str)
+        ],
+        request=ResumeReplaceSerializer,
+        responses={200: ResumeFullSerializer, 400: ErrorSerializer, 404: ErrorSerializer, 500: ErrorSerializer},
+        summary="Replace resume sections",
+        description="Replace all sections of a resume with the provided ordered list of sections."
+    )
+    def update(self, request, pk=None):
+        self.__set_meta(request)
+        # Resolve resume
+        if pk == 'base':
+            resume, _ = self.authenticated_user.resume_set.get_or_create(base=True)
+        else:
+            resume_qs = self.authenticated_user.resume_set.filter(id=pk)
+            if not resume_qs.exists():
+                return ErrorResponse(
+                    code=ErrorCode.NOT_FOUND, message='Resume not found!', details={'resume': pk}
+                ).response
+            resume = resume_qs.first()
+
+        # Validate payload
+        serializer = ResumeReplaceSerializer(data=request.data)
+        if not serializer.is_valid():
+            return ErrorResponse(
+                code=ErrorCode.INVALID_REQUEST, message='Invalid request data.',
+                details=serializer.errors, extra={'data': request.data}
+            ).response
+
+        sections_payload = serializer.validated_data['sections']
+
+        try:
+            with transaction.atomic():
+                # Avoid spamming thumbnail generation while bulk editing
+                with disable_thumbnail_generation():
+                    # Mark resume to skip any signal-based thumbnail generation
+                    setattr(resume, '_skip_thumbnail_generation', True)
+
+                    # Remove all existing sections and cascades
+                    resume.resumesection_set.all().delete()
+
+                    # Recreate incoming sections preserving order
+                    for index, section in enumerate(sections_payload):
+                        section_type = section.get('type')
+                        section_data = section.get('data') or {}
+
+                        if section_type == 'Skill':
+                            if section_data.get('skills'):
+                                new_res_sec: ResumeSection = resume.resumesection_set.create(
+                                    index=index, type=ResumeSection.ResumeSectionType.Skill.value
+                                )
+                                for skill_item in section_data.get('skills'):
+                                    skill_info = (skill_item or {}).get('skill') or {}
+                                    skill_name = skill_info.get('name')
+                                    skill_category = skill_info.get('category')
+                                    if not skill_name:
+                                        continue
+                                    target_skill, _ = Skill.objects.get_or_create(
+                                        name=skill_name, category=skill_category
+                                    )
+                                    target_proficiency, _ = new_res_sec.proficiency_set.get_or_create(
+                                        skill=target_skill
+                                    )
+                                    skill_level = (skill_item or {}).get('level')
+                                    if skill_level and str(skill_level) in Proficiency.Level.values:
+                                        target_proficiency.level = skill_level
+                                    target_proficiency.save()
+
+                        elif section_type == 'Experience':
+                            new_res_sec: ResumeSection = resume.resumesection_set.create(
+                                index=index, type=ResumeSection.ResumeSectionType.Experience.value
+                            )
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = new_res_sec.id
+                            experience_ser = ExperienceUpsertSerializer(data=payload)
+                            if experience_ser.is_valid():
+                                experience_ser.save()
+                            else:
+                                # cleanup the created section before failing
+                                new_res_sec.delete()
+                                return ErrorResponse(
+                                    code=ErrorCode.INVALID_REQUEST,
+                                    message='Invalid Experience data provided.',
+                                    details=experience_ser.errors,
+                                    extra={'data': section_data}
+                                ).response
+
+                        elif section_type == 'Education':
+                            new_res_sec: ResumeSection = resume.resumesection_set.create(
+                                index=index, type=ResumeSection.ResumeSectionType.Education.value
+                            )
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = new_res_sec.id
+                            education_ser = EducationUpsertSerializer(data=payload)
+                            if education_ser.is_valid():
+                                education_ser.save()
+                            else:
+                                new_res_sec.delete()
+                                return ErrorResponse(
+                                    code=ErrorCode.INVALID_REQUEST,
+                                    message='Invalid Education data provided.',
+                                    details=education_ser.errors,
+                                    extra={'data': section_data}
+                                ).response
+
+                        elif section_type == 'Project':
+                            new_res_sec: ResumeSection = resume.resumesection_set.create(
+                                index=index, type=ResumeSection.ResumeSectionType.Project.value
+                            )
+                            payload = dict(section_data)
+                            skills_used = payload.get('skills_used')
+                            if 'skills_used' in payload:
+                                del payload['skills_used']
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = new_res_sec.id
+                            project_ser = ProjectUpsertSerializer(data=payload)
+                            if project_ser.is_valid():
+                                new_project: Project = project_ser.save()
+                                # Align with other endpoints: add skills via model helper
+                                if isinstance(skills_used, list):
+                                    for sk in skills_used:
+                                        if not sk:
+                                            continue
+                                        sk_name = sk.get('name')
+                                        sk_cat = sk.get('category')
+                                        if not sk_name:
+                                            continue
+                                        new_project.add_skill(skill_name=sk_name, skill_category=sk_cat)
+                            else:
+                                new_res_sec.delete()
+                                return ErrorResponse(
+                                    code=ErrorCode.INVALID_REQUEST,
+                                    message='Invalid Project data provided.',
+                                    details=project_ser.errors,
+                                    extra={'data': section_data}
+                                ).response
+
+                        elif section_type == 'Certification':
+                            new_res_sec: ResumeSection = resume.resumesection_set.create(
+                                index=index, type=ResumeSection.ResumeSectionType.Certification.value
+                            )
+                            payload = dict(section_data)
+                            payload['user'] = self.authenticated_user.id
+                            payload['resume_section'] = new_res_sec.id
+                            cert_ser = CertificationUpsertSerializer(data=payload)
+                            if cert_ser.is_valid():
+                                cert_ser.save()
+                            else:
+                                new_res_sec.delete()
+                                return ErrorResponse(
+                                    code=ErrorCode.INVALID_REQUEST,
+                                    message='Invalid Certification data provided.',
+                                    details=cert_ser.errors,
+                                    extra={'data': section_data}
+                                ).response
+                        else:
+                            # Unknown section types are ignored to keep robustness
+                            continue
+
+                    # Clean skip flag before leaving transaction
+                    if hasattr(resume, '_skip_thumbnail_generation'):
+                        delattr(resume, '_skip_thumbnail_generation')
+
+            # Kick off background jobs after successful commit
+            index_resume_by_id_async(resume.id)
+            generate_resume_thumbnail_async(resume)
+
+            return Response(ResumeFullSerializer(resume).data)
+
+        except ValueError as ve:
+            error_response = ErrorResponse(
+                code=ErrorCode.INVALID_REQUEST,
+                message=str(ve),
+                status_code=status.HTTP_400_BAD_REQUEST,
+                details={'data': request.data}
+            )
+            logger.exception(f"{error_response.uuid} -> Invalid request while replacing resume: {ve}")
+            return error_response.response
+        except Exception as e:
+            error_response = ErrorResponse(
+                code=ErrorCode.INTERNAL_SERVER_ERROR,
+                message='Unexpected error occurred while replacing resume.',
+                details=str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+            logger.exception(f"{error_response.uuid} -> Exception while replacing resume: {e}")
+            return error_response.response
 
     @extend_schema(
         request=SectionRearrangeSerializer,

--- a/RESUME/serializers.py
+++ b/RESUME/serializers.py
@@ -345,3 +345,27 @@ class SectionRearrangeSerializer(serializers.Serializer):
         if len(value) != len(set(value)):
             raise serializers.ValidationError("Duplicate section IDs are not allowed.")
         return value
+
+
+class ResumeReplaceSectionSerializer(serializers.Serializer):
+    """
+    Incoming section payload for replacing a resume.
+    This is intentionally permissive on the nested data to allow clients
+    to send the same structure produced by tailoring callbacks.
+    """
+    type = serializers.ChoiceField(
+        choices=['Skill', 'Experience', 'Education', 'Project', 'Certification']
+    )
+    data = serializers.DictField(required=False)
+
+
+class ResumeReplaceSerializer(serializers.Serializer):
+    """
+    Serializer for replacing an entire resume's sections in one request.
+    """
+    sections = serializers.ListField(
+        child=ResumeReplaceSectionSerializer(),
+        min_length=1,
+        allow_empty=False,
+        help_text="Ordered list of sections that will fully replace the resume's sections"
+    )


### PR DESCRIPTION
### Issue:
[LTB-103 | api: API endpoint for replacing an entire resume object with a new object](https://linear.app/letraz/issue/LTB-103/api-api-endpoint-for-replacing-an-entire-resume-object-with-a-new)

### Description:
Implement a new API endpoint in `letraz-server` to allow for the complete replacement of an existing resume object with a new one.

### Changes Made:
- Added a secure `PUT` API endpoint `/api/v1/resumes/<uuid:resume_id>/` for full resume replacement.
- Implemented logic to handle authorization checks, deletion of old data, and creation of new data within a single database transaction.
- Included validation for incoming `Resume` object, asynchronous thumbnail regeneration, and error handling/logging.
- Ensured proper API response on successful replacement and considered implications for future versioning.
- Managed foreign key relationships during deletion and creation to prevent orphaned records.

### Closing Note:
This PR is crucial as it introduces a vital feature allowing users to replace their entire resume content seamlessly, enhancing user experience and data integrity.