### PR TITLE
LTB-94 | api: API endpoint for accepting resume export request

### DIFF
--- a/RESUME/admin.py
+++ b/RESUME/admin.py
@@ -28,6 +28,7 @@ class ResumeAdmin(admin.ModelAdmin):
 @admin.register(ResumeSection)
 class ResumeSectionAdmin(admin.ModelAdmin):
     list_display = ('id', 'resume', 'index', 'type')
+    search_fields = ('id', 'resume__id')
     list_filter = ('type',)
     
     def delete_queryset(self, request, queryset):

--- a/RESUME/api_views.py
+++ b/RESUME/api_views.py
@@ -16,6 +16,7 @@ from CORE.serializers import ErrorEnvelopeSerializer
 from JOB.models import Job
 from JOB.serializers import JobFullSerializer, JobSerializer
 from PROFILE.models import User
+from RESUME.doc_only_serializers import ResumeExportResponse
 from RESUME.models import Resume, Education, Experience, ResumeSection, Proficiency, Project, Certification
 from RESUME.serializers import ResumeShortSerializer, ResumeFullSerializer, EducationFullSerializer, \
     ExperienceFullSerializer, EducationUpsertSerializer, ExperienceUpsertSerializer, ProficiencySerializer, \
@@ -543,6 +544,45 @@ class ResumeViewSets(viewsets.GenericViewSet):
             )
             logger.exception(f'{error_response.uuid} -> Exception while rearranging sections: {e}')
             return error_response.response
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='pk', description='Resume ID', required=True, location='path', type=OpenApiTypes.STR)
+        ],
+        responses={200:ResumeExportResponse, 400: ERROR_ENVELOPE, 404: ERROR_ENVELOPE},
+        summary="Export a resume",
+        description = "Exports a resume by its ID and returns the exported resume's PDF and TEX URL from DigitalOcean CDN"
+    )
+    @action(detail=True, methods=['get'], url_path='export')
+    def export_resume(self, request, pk=None):
+        self.__set_meta(request)
+
+        if pk == 'base':
+            base_resume, created = self.authenticated_user.resume_set.get_or_create(base=True)
+            resume_id = base_resume.id
+            is_base_resume = True
+        else:
+            resume_id = pk
+            is_base_resume = False
+
+        logger.debug(f'Request exporting Resume for resume id: {"[BASE]"if is_base_resume else ''}{resume_id}')
+        resume_by_user_and_resume_id_qs = self.authenticated_user.resume_set.filter(id=resume_id)
+        if resume_by_user_and_resume_id_qs.exists():
+            resume: Resume = resume_by_user_and_resume_id_qs.first()
+            resume_service = letraz_utils_pb2_grpc.ResumeServiceStub(settings.UTIL_GRPC_CHANNEL)
+            req = letraz_utils_pb2.ExportResumeRequest(
+                resume=BaseResumeUtilSerializer(resume, many=False).data, theme="DEFAULT_THEME"
+            )
+            logger.debug(f'Calling ExportResume Resume Response for resume id: {"[BASE]"if is_base_resume else ''}{resume_id} -> \n {BaseResumeUtilSerializer(resume, many=False).data}')
+            res = MessageToDict(resume_service.ExportResume(req))
+            logger.debug(f'ExportResume Resume Response: \n{res}')
+            if res.get('status') == 'FAILURE':
+                return ErrorResponse(code=ErrorCode.INTERNAL_SERVER_ERROR, message='Unknown error occurred!', details=res.get('error'))
+            return Response({"pdf_url": res.get('pdfUrl'), "latex_url": res.get('latexUrl')})
+        else:
+            return ErrorResponse(
+                code=ErrorCode.NOT_FOUND, message='Resume not found!', details={'resume': resume_id}
+            ).response
 
 
 # Education CRUD operations

--- a/RESUME/doc_only_serializers.py
+++ b/RESUME/doc_only_serializers.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+class ResumeExportResponse(serializers.Serializer):
+    pdf_url = serializers.UUIDField(help_text='The public CDN URL of the exported PDF file of the resume')
+    latex_url = serializers.UUIDField(help_text='The public CDN URL of the exported TEX file of the resume')

--- a/letraz_server/conf/grpc_client/utils/letraz-utils.proto
+++ b/letraz_server/conf/grpc_client/utils/letraz-utils.proto
@@ -19,6 +19,9 @@ service ResumeService {
   
   // Generate a screenshot of a resume
   rpc GenerateScreenshot(ResumeScreenshotRequest) returns (ResumeScreenshotResponse);
+
+  // Export a resume to LaTeX and upload to object storage
+  rpc ExportResume(ExportResumeRequest) returns (ExportResumeResponse);
 }
 
 service HealthService {
@@ -111,6 +114,26 @@ message ResumeScreenshotResponse {
   string error = 6;           // Error code/type
 }
 
+// ===== EXPORT MESSAGES =====
+
+message ExportResumeRequest {
+  BaseResume resume = 1;   // Complete resume object to export
+  string theme = 2;        // e.g., "DEFAULT_THEME"
+}
+
+message ExportResumeResponse {
+  // Reserve removed field to avoid accidental reuse
+  reserved 4;
+  reserved "export_url";
+
+  string status = 1;         // SUCCESS, FAILURE
+  string message = 2;        // Status message
+  string timestamp = 3;      // ISO timestamp string
+  string latex_url = 5;      // CDN URL of the uploaded .tex file
+  string pdf_url = 6;        // CDN URL of the uploaded .pdf file
+  string error = 7;          // Error code/type (only for failures)
+}
+
 // ===== HEALTH MESSAGES =====
 
 message HealthCheckRequest {
@@ -144,32 +167,6 @@ message Salary {
   string currency = 1;
   int32 max = 2;
   int32 min = 3;
-}
-
-message SalaryRange {
-  int32 min = 1;
-  int32 max = 2;
-  string currency = 3;
-  string period = 4; // hourly, monthly, yearly
-}
-
-message JobPosting {
-  string id = 1;
-  string title = 2;
-  string company = 3;
-  string location = 4;
-  bool remote = 5;
-  SalaryRange salary = 6;
-  string description = 7;
-  repeated string requirements = 8;
-  repeated string skills = 9;
-  repeated string benefits = 10;
-  string experience_level = 11;
-  string job_type = 12;
-  string posted_date = 13;           // ISO timestamp string
-  string application_url = 14;
-  map<string, string> metadata = 15;
-  string processed_at = 16;          // ISO timestamp string
 }
 
 message ScrapeOptions {

--- a/letraz_server/conf/grpc_client/utils/letraz_utils_pb2.py
+++ b/letraz_server/conf/grpc_client/utils/letraz_utils_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12letraz-utils.proto\x12\tletraz.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x81\x01\n\x10ScrapeJobRequest\x12\x10\n\x03url\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0b\x64\x65scription\x18\x02 \x01(\tH\x01\x88\x01\x01\x12)\n\x07options\x18\x03 \x01(\x0b\x32\x18.letraz.v1.ScrapeOptionsB\x06\n\x04_urlB\x0e\n\x0c_description\"i\n\x11ScrapeJobResponse\x12\x11\n\tprocessId\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\t\x12\r\n\x05\x65rror\x18\x05 \x01(\t\"q\n\nBaseResume\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04\x62\x61se\x18\x02 \x01(\x08\x12\x1d\n\x04user\x18\x03 \x01(\x0b\x32\x0f.letraz.v1.User\x12*\n\x08sections\x18\x04 \x03(\x0b\x32\x18.letraz.v1.ResumeSection\"\x97\x02\n\x04User\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x12\n\nfirst_name\x18\x03 \x01(\t\x12\x11\n\tlast_name\x18\x04 \x01(\t\x12\r\n\x05\x65mail\x18\x05 \x01(\t\x12\r\n\x05phone\x18\x06 \x01(\t\x12\x0b\n\x03\x64ob\x18\x07 \x01(\t\x12\x13\n\x0bnationality\x18\x08 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\t \x01(\t\x12\x0c\n\x04\x63ity\x18\n \x01(\t\x12\x0e\n\x06postal\x18\x0b \x01(\t\x12\x0f\n\x07\x63ountry\x18\x0c \x01(\t\x12\x0f\n\x07website\x18\r \x01(\t\x12\x14\n\x0cprofile_text\x18\x0e \x01(\t\x12\x12\n\ncreated_at\x18\x0f \x01(\t\x12\x12\n\nupdated_at\x18\x10 \x01(\t\"o\n\rResumeSection\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06resume\x18\x02 \x01(\t\x12\r\n\x05index\x18\x03 \x01(\x05\x12\x0c\n\x04type\x18\x04 \x01(\t\x12%\n\x04\x64\x61ta\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\"q\n\x13TailorResumeRequest\x12*\n\x0b\x62\x61se_resume\x18\x01 \x01(\x0b\x32\x15.letraz.v1.BaseResume\x12\x1b\n\x03job\x18\x02 \x01(\x0b\x32\x0e.letraz.v1.Job\x12\x11\n\tresume_id\x18\x03 \x01(\t\"l\n\x14TailorResumeResponse\x12\x11\n\tprocessId\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\t\x12\r\n\x05\x65rror\x18\x05 \x01(\t\",\n\x17ResumeScreenshotRequest\x12\x11\n\tresume_id\x18\x01 \x01(\t\"\x89\x01\n\x18ResumeScreenshotResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\t\x12\x12\n\nprocess_id\x18\x04 \x01(\t\x12\x16\n\x0escreenshot_url\x18\x05 \x01(\t\x12\r\n\x05\x65rror\x18\x06 \x01(\t\"\x14\n\x12HealthCheckRequest\"\xcc\x01\n\x13HealthCheckResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\x12\x16\n\x0euptime_seconds\x18\x04 \x01(\x03\x12:\n\x06\x63hecks\x18\x05 \x03(\x0b\x32*.letraz.v1.HealthCheckResponse.ChecksEntry\x1a-\n\x0b\x43hecksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd3\x01\n\x03Job\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x0f\n\x07job_url\x18\x03 \x01(\t\x12\x14\n\x0c\x63ompany_name\x18\x04 \x01(\t\x12\x10\n\x08location\x18\x05 \x01(\t\x12!\n\x06salary\x18\x06 \x01(\x0b\x32\x11.letraz.v1.Salary\x12\x14\n\x0crequirements\x18\x07 \x03(\t\x12\x13\n\x0b\x64\x65scription\x18\x08 \x01(\t\x12\x18\n\x10responsibilities\x18\t \x03(\t\x12\x10\n\x08\x62\x65nefits\x18\n \x03(\t\"4\n\x06Salary\x12\x10\n\x08\x63urrency\x18\x01 \x01(\t\x12\x0b\n\x03max\x18\x02 \x01(\x05\x12\x0b\n\x03min\x18\x03 \x01(\x05\"I\n\x0bSalaryRange\x12\x0b\n\x03min\x18\x01 \x01(\x05\x12\x0b\n\x03max\x18\x02 \x01(\x05\x12\x10\n\x08\x63urrency\x18\x03 \x01(\t\x12\x0e\n\x06period\x18\x04 \x01(\t\"\xa7\x03\n\nJobPosting\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x0f\n\x07\x63ompany\x18\x03 \x01(\t\x12\x10\n\x08location\x18\x04 \x01(\t\x12\x0e\n\x06remote\x18\x05 \x01(\x08\x12&\n\x06salary\x18\x06 \x01(\x0b\x32\x16.letraz.v1.SalaryRange\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x14\n\x0crequirements\x18\x08 \x03(\t\x12\x0e\n\x06skills\x18\t \x03(\t\x12\x10\n\x08\x62\x65nefits\x18\n \x03(\t\x12\x18\n\x10\x65xperience_level\x18\x0b \x01(\t\x12\x10\n\x08job_type\x18\x0c \x01(\t\x12\x13\n\x0bposted_date\x18\r \x01(\t\x12\x17\n\x0f\x61pplication_url\x18\x0e \x01(\t\x12\x35\n\x08metadata\x18\x0f \x03(\x0b\x32#.letraz.v1.JobPosting.MetadataEntry\x12\x14\n\x0cprocessed_at\x18\x10 \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"q\n\rScrapeOptions\x12\x0e\n\x06\x65ngine\x18\x01 \x01(\t\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\x12\x14\n\x0cllm_provider\x18\x03 \x01(\t\x12\x12\n\nuser_agent\x18\x04 \x01(\t\x12\r\n\x05proxy\x18\x05 \x01(\t2X\n\x0eScraperService\x12\x46\n\tScrapeJob\x12\x1b.letraz.v1.ScrapeJobRequest\x1a\x1c.letraz.v1.ScrapeJobResponse2\xbf\x01\n\rResumeService\x12O\n\x0cTailorResume\x12\x1e.letraz.v1.TailorResumeRequest\x1a\x1f.letraz.v1.TailorResumeResponse\x12]\n\x12GenerateScreenshot\x12\".letraz.v1.ResumeScreenshotRequest\x1a#.letraz.v1.ResumeScreenshotResponse2]\n\rHealthService\x12L\n\x0bHealthCheck\x12\x1d.letraz.v1.HealthCheckRequest\x1a\x1e.letraz.v1.HealthCheckResponseB+Z)letraz-utils/api/proto/letraz/v1;letrazv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12letraz-utils.proto\x12\tletraz.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x81\x01\n\x10ScrapeJobRequest\x12\x10\n\x03url\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x18\n\x0b\x64\x65scription\x18\x02 \x01(\tH\x01\x88\x01\x01\x12)\n\x07options\x18\x03 \x01(\x0b\x32\x18.letraz.v1.ScrapeOptionsB\x06\n\x04_urlB\x0e\n\x0c_description\"i\n\x11ScrapeJobResponse\x12\x11\n\tprocessId\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\t\x12\r\n\x05\x65rror\x18\x05 \x01(\t\"q\n\nBaseResume\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04\x62\x61se\x18\x02 \x01(\x08\x12\x1d\n\x04user\x18\x03 \x01(\x0b\x32\x0f.letraz.v1.User\x12*\n\x08sections\x18\x04 \x03(\x0b\x32\x18.letraz.v1.ResumeSection\"\x97\x02\n\x04User\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x12\n\nfirst_name\x18\x03 \x01(\t\x12\x11\n\tlast_name\x18\x04 \x01(\t\x12\r\n\x05\x65mail\x18\x05 \x01(\t\x12\r\n\x05phone\x18\x06 \x01(\t\x12\x0b\n\x03\x64ob\x18\x07 \x01(\t\x12\x13\n\x0bnationality\x18\x08 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\t \x01(\t\x12\x0c\n\x04\x63ity\x18\n \x01(\t\x12\x0e\n\x06postal\x18\x0b \x01(\t\x12\x0f\n\x07\x63ountry\x18\x0c \x01(\t\x12\x0f\n\x07website\x18\r \x01(\t\x12\x14\n\x0cprofile_text\x18\x0e \x01(\t\x12\x12\n\ncreated_at\x18\x0f \x01(\t\x12\x12\n\nupdated_at\x18\x10 \x01(\t\"o\n\rResumeSection\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06resume\x18\x02 \x01(\t\x12\r\n\x05index\x18\x03 \x01(\x05\x12\x0c\n\x04type\x18\x04 \x01(\t\x12%\n\x04\x64\x61ta\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\"q\n\x13TailorResumeRequest\x12*\n\x0b\x62\x61se_resume\x18\x01 \x01(\x0b\x32\x15.letraz.v1.BaseResume\x12\x1b\n\x03job\x18\x02 \x01(\x0b\x32\x0e.letraz.v1.Job\x12\x11\n\tresume_id\x18\x03 \x01(\t\"l\n\x14TailorResumeResponse\x12\x11\n\tprocessId\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\t\x12\r\n\x05\x65rror\x18\x05 \x01(\t\",\n\x17ResumeScreenshotRequest\x12\x11\n\tresume_id\x18\x01 \x01(\t\"\x89\x01\n\x18ResumeScreenshotResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\t\x12\x12\n\nprocess_id\x18\x04 \x01(\t\x12\x16\n\x0escreenshot_url\x18\x05 \x01(\t\x12\r\n\x05\x65rror\x18\x06 \x01(\t\"K\n\x13\x45xportResumeRequest\x12%\n\x06resume\x18\x01 \x01(\x0b\x32\x15.letraz.v1.BaseResume\x12\r\n\x05theme\x18\x02 \x01(\t\"\x8f\x01\n\x14\x45xportResumeResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\t\x12\x11\n\tlatex_url\x18\x05 \x01(\t\x12\x0f\n\x07pdf_url\x18\x06 \x01(\t\x12\r\n\x05\x65rror\x18\x07 \x01(\tJ\x04\x08\x04\x10\x05R\nexport_url\"\x14\n\x12HealthCheckRequest\"\xcc\x01\n\x13HealthCheckResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\x12\x16\n\x0euptime_seconds\x18\x04 \x01(\x03\x12:\n\x06\x63hecks\x18\x05 \x03(\x0b\x32*.letraz.v1.HealthCheckResponse.ChecksEntry\x1a-\n\x0b\x43hecksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd3\x01\n\x03Job\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05title\x18\x02 \x01(\t\x12\x0f\n\x07job_url\x18\x03 \x01(\t\x12\x14\n\x0c\x63ompany_name\x18\x04 \x01(\t\x12\x10\n\x08location\x18\x05 \x01(\t\x12!\n\x06salary\x18\x06 \x01(\x0b\x32\x11.letraz.v1.Salary\x12\x14\n\x0crequirements\x18\x07 \x03(\t\x12\x13\n\x0b\x64\x65scription\x18\x08 \x01(\t\x12\x18\n\x10responsibilities\x18\t \x03(\t\x12\x10\n\x08\x62\x65nefits\x18\n \x03(\t\"4\n\x06Salary\x12\x10\n\x08\x63urrency\x18\x01 \x01(\t\x12\x0b\n\x03max\x18\x02 \x01(\x05\x12\x0b\n\x03min\x18\x03 \x01(\x05\"q\n\rScrapeOptions\x12\x0e\n\x06\x65ngine\x18\x01 \x01(\t\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\x12\x14\n\x0cllm_provider\x18\x03 \x01(\t\x12\x12\n\nuser_agent\x18\x04 \x01(\t\x12\r\n\x05proxy\x18\x05 \x01(\t2X\n\x0eScraperService\x12\x46\n\tScrapeJob\x12\x1b.letraz.v1.ScrapeJobRequest\x1a\x1c.letraz.v1.ScrapeJobResponse2\x90\x02\n\rResumeService\x12O\n\x0cTailorResume\x12\x1e.letraz.v1.TailorResumeRequest\x1a\x1f.letraz.v1.TailorResumeResponse\x12]\n\x12GenerateScreenshot\x12\".letraz.v1.ResumeScreenshotRequest\x1a#.letraz.v1.ResumeScreenshotResponse\x12O\n\x0c\x45xportResume\x12\x1e.letraz.v1.ExportResumeRequest\x1a\x1f.letraz.v1.ExportResumeResponse2]\n\rHealthService\x12L\n\x0bHealthCheck\x12\x1d.letraz.v1.HealthCheckRequest\x1a\x1e.letraz.v1.HealthCheckResponseB+Z)letraz-utils/api/proto/letraz/v1;letrazv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,8 +35,6 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._serialized_options = b'Z)letraz-utils/api/proto/letraz/v1;letrazv1'
   _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._loaded_options = None
   _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._serialized_options = b'8\001'
-  _globals['_JOBPOSTING_METADATAENTRY']._loaded_options = None
-  _globals['_JOBPOSTING_METADATAENTRY']._serialized_options = b'8\001'
   _globals['_SCRAPEJOBREQUEST']._serialized_start=64
   _globals['_SCRAPEJOBREQUEST']._serialized_end=193
   _globals['_SCRAPEJOBRESPONSE']._serialized_start=195
@@ -55,28 +53,26 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_RESUMESCREENSHOTREQUEST']._serialized_end=1081
   _globals['_RESUMESCREENSHOTRESPONSE']._serialized_start=1084
   _globals['_RESUMESCREENSHOTRESPONSE']._serialized_end=1221
-  _globals['_HEALTHCHECKREQUEST']._serialized_start=1223
-  _globals['_HEALTHCHECKREQUEST']._serialized_end=1243
-  _globals['_HEALTHCHECKRESPONSE']._serialized_start=1246
-  _globals['_HEALTHCHECKRESPONSE']._serialized_end=1450
-  _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._serialized_start=1405
-  _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._serialized_end=1450
-  _globals['_JOB']._serialized_start=1453
-  _globals['_JOB']._serialized_end=1664
-  _globals['_SALARY']._serialized_start=1666
-  _globals['_SALARY']._serialized_end=1718
-  _globals['_SALARYRANGE']._serialized_start=1720
-  _globals['_SALARYRANGE']._serialized_end=1793
-  _globals['_JOBPOSTING']._serialized_start=1796
-  _globals['_JOBPOSTING']._serialized_end=2219
-  _globals['_JOBPOSTING_METADATAENTRY']._serialized_start=2172
-  _globals['_JOBPOSTING_METADATAENTRY']._serialized_end=2219
-  _globals['_SCRAPEOPTIONS']._serialized_start=2221
-  _globals['_SCRAPEOPTIONS']._serialized_end=2334
-  _globals['_SCRAPERSERVICE']._serialized_start=2336
-  _globals['_SCRAPERSERVICE']._serialized_end=2424
-  _globals['_RESUMESERVICE']._serialized_start=2427
-  _globals['_RESUMESERVICE']._serialized_end=2618
-  _globals['_HEALTHSERVICE']._serialized_start=2620
-  _globals['_HEALTHSERVICE']._serialized_end=2713
+  _globals['_EXPORTRESUMEREQUEST']._serialized_start=1223
+  _globals['_EXPORTRESUMEREQUEST']._serialized_end=1298
+  _globals['_EXPORTRESUMERESPONSE']._serialized_start=1301
+  _globals['_EXPORTRESUMERESPONSE']._serialized_end=1444
+  _globals['_HEALTHCHECKREQUEST']._serialized_start=1446
+  _globals['_HEALTHCHECKREQUEST']._serialized_end=1466
+  _globals['_HEALTHCHECKRESPONSE']._serialized_start=1469
+  _globals['_HEALTHCHECKRESPONSE']._serialized_end=1673
+  _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._serialized_start=1628
+  _globals['_HEALTHCHECKRESPONSE_CHECKSENTRY']._serialized_end=1673
+  _globals['_JOB']._serialized_start=1676
+  _globals['_JOB']._serialized_end=1887
+  _globals['_SALARY']._serialized_start=1889
+  _globals['_SALARY']._serialized_end=1941
+  _globals['_SCRAPEOPTIONS']._serialized_start=1943
+  _globals['_SCRAPEOPTIONS']._serialized_end=2056
+  _globals['_SCRAPERSERVICE']._serialized_start=2058
+  _globals['_SCRAPERSERVICE']._serialized_end=2146
+  _globals['_RESUMESERVICE']._serialized_start=2149
+  _globals['_RESUMESERVICE']._serialized_end=2421
+  _globals['_HEALTHSERVICE']._serialized_start=2423
+  _globals['_HEALTHSERVICE']._serialized_end=2516
 # @@protoc_insertion_point(module_scope)

--- a/letraz_server/conf/grpc_client/utils/letraz_utils_pb2_grpc.py
+++ b/letraz_server/conf/grpc_client/utils/letraz_utils_pb2_grpc.py
@@ -123,6 +123,11 @@ class ResumeServiceStub(object):
                 request_serializer=letraz__utils__pb2.ResumeScreenshotRequest.SerializeToString,
                 response_deserializer=letraz__utils__pb2.ResumeScreenshotResponse.FromString,
                 _registered_method=True)
+        self.ExportResume = channel.unary_unary(
+                '/letraz.v1.ResumeService/ExportResume',
+                request_serializer=letraz__utils__pb2.ExportResumeRequest.SerializeToString,
+                response_deserializer=letraz__utils__pb2.ExportResumeResponse.FromString,
+                _registered_method=True)
 
 
 class ResumeServiceServicer(object):
@@ -142,6 +147,13 @@ class ResumeServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ExportResume(self, request, context):
+        """Export a resume to LaTeX and upload to object storage
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_ResumeServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -154,6 +166,11 @@ def add_ResumeServiceServicer_to_server(servicer, server):
                     servicer.GenerateScreenshot,
                     request_deserializer=letraz__utils__pb2.ResumeScreenshotRequest.FromString,
                     response_serializer=letraz__utils__pb2.ResumeScreenshotResponse.SerializeToString,
+            ),
+            'ExportResume': grpc.unary_unary_rpc_method_handler(
+                    servicer.ExportResume,
+                    request_deserializer=letraz__utils__pb2.ExportResumeRequest.FromString,
+                    response_serializer=letraz__utils__pb2.ExportResumeResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -210,6 +227,33 @@ class ResumeService(object):
             '/letraz.v1.ResumeService/GenerateScreenshot',
             letraz__utils__pb2.ResumeScreenshotRequest.SerializeToString,
             letraz__utils__pb2.ResumeScreenshotResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def ExportResume(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/letraz.v1.ResumeService/ExportResume',
+            letraz__utils__pb2.ExportResumeRequest.SerializeToString,
+            letraz__utils__pb2.ExportResumeResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/schema.yml
+++ b/schema.yml
@@ -427,6 +427,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
           description: ''
+  /resume/{id}/export/:
+    get:
+      operationId: resume_export_retrieve
+      description: Exports a resume by its ID and returns the exported resume's PDF
+        and TEX URL from DigitalOcean CDN
+      summary: Export a resume
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: pk
+        schema:
+          type: string
+        description: Resume ID
+        required: true
+      tags:
+      - Resume object
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResumeExportResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: ''
   /resume/{id}/sections/rearrange/:
     put:
       operationId: resume_sections_rearrange_update
@@ -3195,6 +3238,20 @@ components:
       - resume_section
       - updated_at
       - user
+    ResumeExportResponse:
+      type: object
+      properties:
+        pdf_url:
+          type: string
+          format: uuid
+          description: The public CDN URL of the exported PDF file of the resume
+        latex_url:
+          type: string
+          format: uuid
+          description: The public CDN URL of the exported TEX file of the resume
+      required:
+      - latex_url
+      - pdf_url
     ResumeFull:
       type: object
       properties:


### PR DESCRIPTION
### Issue:
[LTB-94 | api: API endpoint for accepting resume export request](https://linear.app/letraz/issue/LTB-94/api-api-endpoint-for-accepting-resume-export-request)

### Description:
Implement a new API endpoint in `letraz-server` to handle user requests for exporting resumes.

### Changes Made:
- Added a new `GET` API endpoint `/api/v1/resumes/<uuid:resume_id>/export/` in `letraz-server`.
- Implemented data retrieval of the full `Resume` object and its sections for export.
- Integrated a gRPC client call to `letraz-utils` for resume file generation.
- Defined a new `ExportResume` gRPC method in `letraz-utils` for exporting resumes.
- Implemented error handling and logging for secure and robust operation.

### Closing Note:
This PR is crucial as it enables users to request and receive their exported resumes securely and efficiently through the new API endpoint.