### PR TITLE
LTB-115 | bug: Resume tailoring fails if user has a defined country in their address

### DIFF
--- a/RESUME/serializers.py
+++ b/RESUME/serializers.py
@@ -72,7 +72,25 @@ class BaseResumeUtilSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_user(resume: Resume):
-        return UserSerializer(resume.user).data
+        user = resume.user
+        return {
+            'id': str(user.id),
+            'title': user.title or '',
+            'first_name': user.first_name or '',
+            'last_name': user.last_name or '',
+            'email': user.email or '',
+            'phone': user.phone or '',
+            'dob': user.dob.isoformat() if getattr(user, 'dob', None) else '',
+            'nationality': user.nationality or '',
+            'address': user.address or '',
+            'city': user.city or '',
+            'postal': user.postal or '',
+            'country': user.country.code if getattr(user, 'country_id', None) else '',
+            'website': user.website or '',
+            'profile_text': user.profile_text or '',
+            'created_at': user.created_at.isoformat() if getattr(user, 'created_at', None) else '',
+            'updated_at': user.updated_at.isoformat() if getattr(user, 'updated_at', None) else '',
+        }
 
     @staticmethod
     def get_sections(resume: Resume):


### PR DESCRIPTION
### Issue:
[LTB-115 | bug: Resume tailoring fails if user has a defined country in their address](https://linear.app/letraz/issue/LTB-115/bug-resume-tailoring-fails-if-user-has-a-defined-country-in-their)

### Description:
This pull request addresses the critical bug causing the resume tailoring process to fail when a user has a `country` field defined in their personal address details.

### Changes Made:
- Updated `.proto` definition for `PersonalInfo` to accurately reflect the structure of the `country` field.
- Modified `letraz-server`'s serialization logic to transform the `country` field correctly for `letraz-utils`.
- Adjusted `letraz-utils`'s Go code to deserialize the incoming `country` field accurately.
- Created dedicated test cases for resume tailoring with fully defined `country` fields.
- Added debug logging to trace `PersonalInfo` object and `country` field during the `TailorResume` call.

### Closing Note:
This PR is crucial as it ensures that users with complete address information can successfully tailor their resumes without encountering failures due to the presence of a `country` field.