### PR TITLE
impr: add job link to resume-ready email

### DIFF
--- a/services/notifications/actions.ts
+++ b/services/notifications/actions.ts
@@ -205,7 +205,8 @@ const resumeTailoringSuccessEventListener = new Subscription(resumeTailoringSucc
 					job_id: event.job_id,
 					cta_url: `${CLIENT_URL}/app/craft/resumes/${event.resume_id}`,
 					job_title: job?.title !== '<EXTRACTION_FAILED>' ? job.title : null,
-					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null
+					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null,
+					job_url: job?.job_url!== '<EXTRACTION_FAILED>' ? job.job_url : null
 				}
 			})
 
@@ -216,7 +217,8 @@ const resumeTailoringSuccessEventListener = new Subscription(resumeTailoringSucc
 				user_id: event.user_id,
 				user_email: user.email,
 				job_title: job?.title,
-				company_name: job?.company_name
+				company_name: job?.company_name,
+				job_url: job?.job_url
 			})
 		} catch (err) {
 			log.error(err as Error, 'Failed to process resume-tailoring-success event', {


### PR DESCRIPTION
**Description**
This PR improves the resume-ready email flow by including the job link when available. Users will now receive the associated job posting link directly in the email once their tailored resume is ready.

**Changes Included**
- Added backend support to pass the job link to the Knock notification workflow.
- Updated the corresponding email template in Knock to display the job link when provided.
- Ensured the update is fully optional and gracefully skipped when no job link exists.