### PR TITLE
impr: add job link in job import failure email

### DIFF
--- a/services/notifications/actions.ts
+++ b/services/notifications/actions.ts
@@ -125,7 +125,9 @@ const resumeTailoringFailedEventListener = new Subscription(resumeTailoringFaile
 					reason: event.error_message,
 					report_url: `${CLIENT_URL}/app/support?resumeId=${event.resume_id}`,
 					job_title: job?.title !== '<EXTRACTION_FAILED>' ? job.title : null,
-					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null
+					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null,
+					job_url: job?.job_url !== '<EXTRACTION_FAILED>' ? job.job_url : null
+
 				}
 			})
 

--- a/services/notifications/actions.ts
+++ b/services/notifications/actions.ts
@@ -205,7 +205,8 @@ const resumeTailoringSuccessEventListener = new Subscription(resumeTailoringSucc
 					job_id: event.job_id,
 					cta_url: `${CLIENT_URL}/app/craft/resumes/${event.resume_id}`,
 					job_title: job?.title !== '<EXTRACTION_FAILED>' ? job.title : null,
-					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null
+					company_name: job?.company_name !== '<EXTRACTION_FAILED>' ? job.company_name : null,
+					job_url: job?.job_url!== '<EXTRACTION_FAILED>' ? job.job_url : null
 				}
 			})
 
@@ -216,7 +217,8 @@ const resumeTailoringSuccessEventListener = new Subscription(resumeTailoringSucc
 				user_id: event.user_id,
 				user_email: user.email,
 				job_title: job?.title,
-				company_name: job?.company_name
+				company_name: job?.company_name,
+				job_url: job?.job_url
 			})
 		} catch (err) {
 			log.error(err as Error, 'Failed to process resume-tailoring-success event', {


### PR DESCRIPTION
**Description**
This PR improves the job import failure notification by including the original job link when available. This gives users clarity on which job failed to import and allows them to retry or manually provide the job description.

**Changes Included**
- Added job_url to the resumeTailoringFailed workflow payload.
- Updated the Knock email template to show the job link inline when present.
- Added graceful fallback messaging when no job link is provided.